### PR TITLE
Let dashboard be viewed without auth. Sign out on dashboard.

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -9,6 +9,7 @@ import * as moment from "moment";
 import { Serving } from "./Serving";
 import { LineQrLink } from "./LineQrLink";
 import { useAcceptingNumbers } from "../hooks/useAcceptingNumbers";
+import { useSignOut } from "../hooks/useSignOut";
 
 const styleBuilder = ({ colors: { text }, font }: Theme) => ({
   layout: {
@@ -31,6 +32,7 @@ export const Dashboard = () => {
   const averageWait = useAverageServiceTime();
   const estimatedWait = moment.duration(lineCount * averageWait);
   const accepting = useAcceptingNumbers();
+  useSignOut();
   return (
     <div css={styles.layout}>
       {accepting && <LineQrLink />}

--- a/src/hooks/useSignOut.ts
+++ b/src/hooks/useSignOut.ts
@@ -1,0 +1,13 @@
+import { useFirebaseAuth } from "../context/firebaseAuthContext";
+import { useEffect } from "react";
+
+export const useSignOut = () => {
+  const auth = useFirebaseAuth();
+  const user = auth && auth.currentUser;
+  return useEffect(() => {
+    if (!auth || !user) {
+      return () => {};
+    }
+    auth.signOut();
+  }, [auth, user]);
+};


### PR DESCRIPTION
Remove auth from the dashboard page.

Fixes #36 
Fixes #35 